### PR TITLE
Do not show Paste Invoice on empty clipboard text and add pasteButtonText parameter

### DIFF
--- a/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScanPlugin.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScanPlugin.kt
@@ -25,14 +25,16 @@ class BarcodeScanPlugin(val activity: Activity): MethodCallHandler,
   override fun onMethodCall(call: MethodCall, result: Result): Unit {
     if (call.method.equals("scan")) {
       this.result = result
-      showBarcodeView()
+      var pasteButtonText: String? = call.argument("pasteButtonText")
+      showBarcodeView(pasteButtonText)
     } else {
       result.notImplemented()
     }
   }
 
-  private fun showBarcodeView() {
+  private fun showBarcodeView(pasteButtonText: String?) {
     val intent = Intent(activity, BarcodeScannerActivity::class.java)
+    intent.putExtra("pasteButtonText", pasteButtonText)
     activity.startActivityForResult(intent, 100)
   }
 

--- a/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
@@ -15,6 +15,7 @@ import android.view.LayoutInflater
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.widget.Button
+import android.view.View
 
 
 class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
@@ -55,14 +56,17 @@ class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
             this.invalidateOptionsMenu()
         }
         var pasteBtn = findViewById<Button>(R.id.PASTE)
-        pasteBtn.setOnClickListener {
-            val intent = Intent()
-            val clip = clipboard?.primaryClip
-            val pasteText = clip?.getItemAt(0)
-            val returnVal = if (pasteText?.text != null) pasteText?.text.toString() else ""
-            intent.putExtra("SCAN_RESULT", returnVal)
-            setResult(Activity.RESULT_OK, intent)
-            finish()
+        val intent = Intent()
+        val clip = clipboard?.primaryClip
+        val pasteText = clip?.getItemAt(0)
+        if (pasteText?.text == null) {
+            pasteBtn.setVisibility(View.GONE)
+        } else {
+            pasteBtn.setOnClickListener {
+                intent.putExtra("SCAN_RESULT", pasteText?.text.toString())
+                setResult(Activity.RESULT_OK, intent)
+                finish()
+            }
         }
 
     }

--- a/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
@@ -22,6 +22,7 @@ class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
 
     lateinit var scannerView: me.dm7.barcodescanner.zxing.ZXingScannerView
     private var clipboard: ClipboardManager? = null
+    private var pasteText: ClipData.Item? = null
 
     companion object {
         val REQUEST_TAKE_PHOTO_CAMERA_PERMISSION = 100
@@ -58,17 +59,15 @@ class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
         var pasteBtn = findViewById<Button>(R.id.PASTE)
         val intent = Intent()
         val clip = clipboard?.primaryClip
-        val pasteText = clip?.getItemAt(0)
-        if (pasteText?.text == null) {
-            pasteBtn.setVisibility(View.GONE)
-        } else {
-            pasteBtn.setOnClickListener {
-                intent.putExtra("SCAN_RESULT", pasteText?.text.toString())
-                setResult(Activity.RESULT_OK, intent)
-                finish()
-            }
+        pasteText = clip?.getItemAt(0)
+        pasteBtn.setOnClickListener {
+            intent.putExtra("SCAN_RESULT", pasteText?.text.toString())
+            setResult(Activity.RESULT_OK, intent)
+            finish()
         }
-
+        if (pasteText?.text == null) {
+            pasteBtn.setVisibility(View.INVISIBLE)
+        }
     }
 
     override fun onResume() {
@@ -77,6 +76,14 @@ class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
         // start camera immediately if permission is already given
         if (!requestCameraAccessIfNecessary()) {
             scannerView.startCamera()
+        }
+        // show Paste Invoice button if there's a valid item in clipboard
+        clipboard = getSystemService(CLIPBOARD_SERVICE) as ClipboardManager?
+        val clip = clipboard?.primaryClip
+        pasteText = clip?.getItemAt(0)
+        if (pasteText?.text != null) {
+            var pasteBtn = findViewById<Button>(R.id.PASTE)
+            pasteBtn.setVisibility(View.VISIBLE)
         }
     }
 

--- a/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
@@ -16,7 +16,7 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import android.widget.Button
 import android.view.View
-
+import android.content.ClipData
 
 class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
 

--- a/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
@@ -59,7 +59,8 @@ class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
             val intent = Intent()
             val clip = clipboard?.primaryClip
             val pasteText = clip?.getItemAt(0)
-            intent.putExtra("SCAN_RESULT", pasteText?.text.toString())
+            val returnVal = if (pasteText?.text != null) pasteText?.text.toString() else ""
+            intent.putExtra("SCAN_RESULT", returnVal)
             setResult(Activity.RESULT_OK, intent)
             finish()
         }

--- a/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
@@ -57,6 +57,17 @@ class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
             this.invalidateOptionsMenu()
         }
         var pasteBtn = findViewById<Button>(R.id.PASTE)
+        val bundle: Bundle? = intent.extras
+        bundle?.let {
+            bundle.apply {
+                //Intent with data
+                val pasteButtonText: String? = getString("pasteButtonText")
+                if (pasteButtonText != null) {
+                    pasteBtn.text = pasteButtonText
+                }
+
+            }
+        }
         val intent = Intent()
         val clip = clipboard?.primaryClip
         pasteText = clip?.getItemAt(0)

--- a/lib/barcode_scan.dart
+++ b/lib/barcode_scan.dart
@@ -6,5 +6,5 @@ class BarcodeScanner {
   static const CameraAccessDenied = 'PERMISSION_NOT_GRANTED';
   static const MethodChannel _channel =
       const MethodChannel('com.apptreesoftware.barcode_scan');
-  static Future<String> scan() async => await _channel.invokeMethod('scan');
+  static Future<String> scan({String pasteButtonText}) async => await _channel.invokeMethod('scan', {'pasteButtonText': pasteButtonText});
 }


### PR DESCRIPTION
Paste Invoice button is removed if the clipboard item's text is empty.
Add optional pasteButtonText parameter to alter the paste invoice buttons text.